### PR TITLE
Fix library file reaper_reapack64.so

### DIFF
--- a/linux/build.sh
+++ b/linux/build.sh
@@ -182,7 +182,7 @@ echo "Done."
 
 echo "Copying Ultraschall plugins..."
 cp ../js-extension/reaper_js_ReaScriptAPI64.so installer-package/plugins/reaper_js_ReaScriptAPI64.so
-cp ../reapack-extension/reaper_reapack64.so installer-package/plugins/reaper_reapack64.so
+cp ../reapack-extension/reaper_reapack-x86_64.so installer-package/plugins/reaper_reapack-x86_64.so
 cp ../sws-extension/reaper_sws-x86_64.so installer-package/plugins/reaper_sws-x86_64.so
 cp ../sws-extension/sws_python64.py installer-package/scripts/sws_python64.py
 cp ../sws-extension/sws_python.py installer-package/scripts/sws_python.py


### PR DESCRIPTION
- [X] If your changes are large or otherwise disruptive: You have made sure your changes don't interfere with current development by talking it through with the maintainers, e.g. through a Brainstorming ticket
- [X] Your PR targets Ultraschall's development branch (3.x), or maintenance if it's a bug fix for an issue present in the current stable version (no PRs against master or anything else please)
- [X] Your PR was opened from a custom branch on your repository (no PRs from your version of master, maintenance or development please), e.g. dev/my_new_feature or fix/my_bugfix
- [X] Your PR only contains relevant changes: no unrelated files, no dead code, ideally only one commit - rebase and squash your PR if necessary!
- [X] Your changes follow the existing coding style
- [X] You have tested your changes (please state how!)

I built the package on Fedora Linux (see also my other PR https://github.com/Ultraschall/ultraschall-plugin/pull/18). When trying to build, it complained about not being able to copy `reaper_reapack64.so`. Checking the folder, I found `reaper_reapack-x86_64.so` and first just changed the source file to copy over to the original name. When loading Reaper, it complained about the old name too. After I changed also the target file to the new name, the import worked and Reaper loaded without any complaints (Reaper version 6.27). I assume the library file name changed at some point in the past.

**What does this PR do and why is it necessary?**

Building the installer failed because the name changed. Also, Reaper complained about the user plugin library name.

**How was it tested? How can it be tested by the reviewer?**

Installed reaper, built the installer package and then ran the installer.

**Any background context you want to provide?**

No.

**What are the relevant tickets if any?**

No ticket.

**Screenshots (if appropriate)**

No relevant screenshots.

**Further notes**

I don't have any other Distribution to test here, but was wondering whether this breaks any Ubuntu/Arch builds or if they have been broken too.
